### PR TITLE
fixing repo link

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "xo && ava"
   },
   "license": "MIT",
-  "repository": "zeit/release",
+  "repository": "zeit/async-retry",
   "ava": {
     "failFast": true
   },


### PR DESCRIPTION
was pointing to `zeit/release`