### PR TITLE
Add `files` back to `package.json`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "async-retry",
   "version": "1.2.1",
   "description": "Retrying made simple, easy and async",
+  "files": [
+    "lib"
+  ],
   "main": "./lib/index.js",
   "scripts": {
     "test": "xo && ava"


### PR DESCRIPTION
It was removed in #38 and I didn't see any explanation for that.