### PR TITLE
Document onRetry's second parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ retry(retrier : Function, opts : Object) => Promise
   * `minTimeout`: The number of milliseconds before starting the first retry. Default is `1000`.
   * `maxTimeout`: The maximum number of milliseconds between two retries. Default is `Infinity`.
   * `randomize`: Randomizes the timeouts by multiplying with a factor between `1` to `2`. Default is `true`.
-  * `onRetry`: an optional `Function` that is invoked after a new retry is performed. It's passed the `Error` that triggered it as a parameter.
+  * `onRetry`: an optional `Function` that is invoked after a new retry is performed. It's passed the `Error` that triggered it as the first parameter, and the attempt number as the second parameter.
 
 ## Authors
 


### PR DESCRIPTION
The `onRetry` functions accepts a second undocumented parameter that corresponds to the attempt number: https://github.com/zeit/async-retry/blob/f64b83de88b6018796ff84a099d28ed7007e83c1/lib/index.js#L33

Credit to @bertyhell for bringing this up on DefinitelyTyped/DefinitelyTyped#34189