### PR TITLE
Prevent propagating "bail" to upper retry block

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,13 +4,14 @@ var retrier = require('retry');
 function retry(fn, opts) {
   function run(resolve, reject) {
     var options = opts || {};
+    var op;
 
     // Default `randomize` to true
-    if (!'randomize' in opts) {
-      opts.randomize = true;
+    if (!('randomize' in options)) {
+      options.randomize = true;
     }
 
-    var op = retrier.operation(options);
+    op = retrier.operation(options);
 
     // We allow the user to abort retrying
     // this makes sense in the cases where

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,6 +24,8 @@ function retry(fn, opts) {
 
     function onError(err, num) {
       if (err.bail) {
+        // eslint-disable-next-line no-param-reassign
+        delete err.bail;
         bail(err);
         return;
       }

--- a/test/index.js
+++ b/test/index.js
@@ -93,16 +93,18 @@ test('bail error', async t => {
 });
 
 test('nested bail', async t => {
-  let retries = 0;
+  let retries1 = 0;
+  let retries2 = 0;
 
   try {
     await retry(
       async () => {
+        retries1 += 1;
         await retry(
           async () => {
-            retries += 1;
+            retries2 += 1;
             await sleep(100);
-            const err = new Error('Wont retry');
+            const err = new Error('woot');
             err.bail = true;
             throw err;
           },
@@ -112,10 +114,11 @@ test('nested bail', async t => {
       { factor: 1, retries: 7 }
     );
   } catch (err) {
-    t.deepEqual('Wont retry', err.message);
+    t.deepEqual('woot', err.message);
   }
 
-  t.deepEqual(retries, 8);
+  t.deepEqual(retries1, 8);
+  t.deepEqual(retries2, 8);
 });
 
 test('with non-async functions', async t => {

--- a/test/index.js
+++ b/test/index.js
@@ -92,6 +92,32 @@ test('bail error', async t => {
   t.deepEqual(retries, 1);
 });
 
+test('nested bail', async t => {
+  let retries = 0;
+
+  try {
+    await retry(
+      async () => {
+        await retry(
+          async () => {
+            retries += 1;
+            await sleep(100);
+            const err = new Error('Wont retry');
+            err.bail = true;
+            throw err;
+          },
+          { retries: 3 }
+        );
+      },
+      { factor: 1, retries: 7 }
+    );
+  } catch (err) {
+    t.deepEqual('Wont retry', err.message);
+  }
+
+  t.deepEqual(retries, 8);
+});
+
 test('with non-async functions', async t => {
   try {
     await retry(


### PR DESCRIPTION
Currently in nested retry calls the upper one gets `bail = true` if the lower one calls `bail()`. Let's clear the flag so that the upper one decides it independently.