### PR TITLE
[FIX]: Make parameter opts optional again.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,8 +6,8 @@ function retry(fn, opts) {
     var options = opts || {};
 
     // Default `randomize` to true
-    if (!'randomize' in opts) {
-      opts.randomize = true;
+    if (!('randomize' in options)) {
+      options.randomize = true;
     }
 
     var op = retrier.operation(options);


### PR DESCRIPTION
Hi everyone,

with the release of v1.3.0 the parameter `opts` became mandatory because of [this block](https://github.com/zeit/async-retry/blob/master/lib/index.js#L9-L11). Since it checks the original `opts` instead of the modified `options`, not passing `opts` breaks `retry`.

To commit this change I had to disable the commit hook, since the [var declaration not at the top of the function](https://github.com/zeit/async-retry/blob/master/lib/index.js#L13) goes against the linter rules, but I thought I should let you decide on how to deal with your code style.

This PR will still break your CI pipeline because of the linter, but the unit tests now pass again.

Kind regards,
yeldiR