### PR TITLE
make sure that the underlying retry operation is stopped on bail

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,8 @@ function retry(fn, opts) {
     // would be futile (e.g.: auth errors)
 
     function bail(err) {
+      // forcibly prevent any retries
+      op.stop();
       reject(err || new Error('Aborted'));
     }
 


### PR DESCRIPTION
If you use `bail()` to force rejection of the promise, I noticed that if you also still rejected it (by throwing an error) the underlying retries still happened.

This prevents any further retries if the promise is still rejected after the bail call.