### PR TITLE
commonjs -> ecmascript modules

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 // Packages
-var retrier = require('retry');
+import retrier from 'retry'
 
 function retry(fn, opts) {
   function run(resolve, reject) {
@@ -58,4 +58,4 @@ function retry(fn, opts) {
   return new Promise(run);
 }
 
-module.exports = retry;
+export default retry


### PR DESCRIPTION
similar to https://github.com/tim-kos/node-retry/pull/87

paves the way for

```html
<script type="importmap">
      {
        "imports": {
          "retry": "https://cdn.jsdelivr.net/gh/brandonros/node-retry@mjs/index.mjs",
          "async-retry": "https://cdn.jsdelivr.net/gh/brandonros/async-retry@patch-1/lib/index.js"
        }
      }
    </script>
    <script type="module">
      import retry from 'async-retry'

```