### PR TITLE
Setting retry timeout on entire retry operation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,14 +2,15 @@
 var retrier = require('retry');
 
 function retry(fn, opts) {
-  function run(resolve, reject) {
-    var options = opts || {};
-    var op;
+  var options = opts || {};
 
-    // Default `randomize` to true
-    if (!('randomize' in options)) {
-      options.randomize = true;
-    }
+  // Default `randomize` to true
+  if (!('randomize' in options)) {
+    options.randomize = true;
+  }
+
+  function run(resolve, reject) {
+    var op;
 
     op = retrier.operation(options);
 
@@ -55,7 +56,18 @@ function retry(fn, opts) {
     op.attempt(runAttempt);
   }
 
-  return new Promise(run);
+  // Setting up overall timeout for a retry
+  const { retryTimeout } = options;
+  return retryTimeout
+    ? Promise.race([
+        new Promise(run),
+        new Promise((_, reject) => {
+          setTimeout(() => {
+            reject(new Error(`Retry timed out in ${retryTimeout}ms`));
+          }, retryTimeout);
+        }),
+      ])
+    : new Promise(run);
 }
 
 module.exports = retry;

--- a/test/index.js
+++ b/test/index.js
@@ -6,7 +6,7 @@ const sleep = require('then-sleep');
 // Ours
 const retry = require('../lib');
 
-test('return value', async t => {
+test('return value', async (t) => {
   const val = await retry(async (bail, num) => {
     if (num < 2) {
       throw new Error('woot');
@@ -19,12 +19,12 @@ test('return value', async t => {
   t.deepEqual('woot 2', val);
 });
 
-test('return value no await', async t => {
+test('return value no await', async (t) => {
   const val = await retry(async (bail, num) => num);
   t.deepEqual(1, val);
 });
 
-test('chained promise', async t => {
+test('chained promise', async (t) => {
   const res = await retry(async (bail, num) => {
     if (num < 2) {
       throw new Error('retry');
@@ -36,7 +36,7 @@ test('chained promise', async t => {
   t.deepEqual(200, res.status);
 });
 
-test('bail', async t => {
+test('bail', async (t) => {
   try {
     await retry(
       async (bail, num) => {
@@ -53,12 +53,12 @@ test('bail', async t => {
   }
 });
 
-test('bail + return', async t => {
+test('bail + return', async (t) => {
   let error;
 
   try {
     await Promise.resolve(
-      retry(async bail => {
+      retry(async (bail) => {
         await sleep(200);
         await sleep(200);
         bail(new Error('woot'));
@@ -71,7 +71,7 @@ test('bail + return', async t => {
   t.deepEqual(error.message, 'woot');
 });
 
-test('bail error', async t => {
+test('bail error', async (t) => {
   let retries = 0;
 
   try {
@@ -92,7 +92,7 @@ test('bail error', async t => {
   t.deepEqual(retries, 1);
 });
 
-test('with non-async functions', async t => {
+test('with non-async functions', async (t) => {
   try {
     await retry(
       (bail, num) => {
@@ -105,12 +105,12 @@ test('with non-async functions', async t => {
   }
 });
 
-test('return non-async', async t => {
+test('return non-async', async (t) => {
   const val = await retry(() => 5);
   t.deepEqual(5, val);
 });
 
-test('with number of retries', async t => {
+test('with number of retries', async (t) => {
   let retries = 0;
 
   try {
@@ -123,9 +123,25 @@ test('with number of retries', async t => {
         }
 
         retries = i;
-      }
+      },
     });
   } catch (err) {
     t.deepEqual(retries, 2);
+  }
+});
+
+test('with retry timeout', async (t) => {
+  const retryTimeout = 2000;
+  try {
+    await retry(
+      async () => {
+        await sleep(3000);
+      },
+      {
+        retryTimeout,
+      }
+    );
+  } catch (err) {
+    t.deepEqual(err.message, `Retry timed out in ${retryTimeout}ms`);
   }
 });

--- a/test/index.js
+++ b/test/index.js
@@ -6,7 +6,7 @@ const sleep = require('then-sleep');
 // Ours
 const retry = require('../lib');
 
-test('return value', async (t) => {
+test('return value', async t => {
   const val = await retry(async (bail, num) => {
     if (num < 2) {
       throw new Error('woot');
@@ -19,12 +19,12 @@ test('return value', async (t) => {
   t.deepEqual('woot 2', val);
 });
 
-test('return value no await', async (t) => {
+test('return value no await', async t => {
   const val = await retry(async (bail, num) => num);
   t.deepEqual(1, val);
 });
 
-test('chained promise', async (t) => {
+test('chained promise', async t => {
   const res = await retry(async (bail, num) => {
     if (num < 2) {
       throw new Error('retry');
@@ -36,7 +36,7 @@ test('chained promise', async (t) => {
   t.deepEqual(200, res.status);
 });
 
-test('bail', async (t) => {
+test('bail', async t => {
   try {
     await retry(
       async (bail, num) => {
@@ -53,12 +53,12 @@ test('bail', async (t) => {
   }
 });
 
-test('bail + return', async (t) => {
+test('bail + return', async t => {
   let error;
 
   try {
     await Promise.resolve(
-      retry(async (bail) => {
+      retry(async bail => {
         await sleep(200);
         await sleep(200);
         bail(new Error('woot'));
@@ -71,7 +71,7 @@ test('bail + return', async (t) => {
   t.deepEqual(error.message, 'woot');
 });
 
-test('bail error', async (t) => {
+test('bail error', async t => {
   let retries = 0;
 
   try {
@@ -92,7 +92,7 @@ test('bail error', async (t) => {
   t.deepEqual(retries, 1);
 });
 
-test('with non-async functions', async (t) => {
+test('with non-async functions', async t => {
   try {
     await retry(
       (bail, num) => {
@@ -105,12 +105,12 @@ test('with non-async functions', async (t) => {
   }
 });
 
-test('return non-async', async (t) => {
+test('return non-async', async t => {
   const val = await retry(() => 5);
   t.deepEqual(5, val);
 });
 
-test('with number of retries', async (t) => {
+test('with number of retries', async t => {
   let retries = 0;
 
   try {
@@ -123,14 +123,14 @@ test('with number of retries', async (t) => {
         }
 
         retries = i;
-      },
+      }
     });
   } catch (err) {
     t.deepEqual(retries, 2);
   }
 });
 
-test('with retry timeout', async (t) => {
+test('with retry timeout', async t => {
   const retryTimeout = 2000;
   try {
     await retry(


### PR DESCRIPTION
The following issue inspires this PR.

https://github.com/vercel/async-retry/issues/73#issue-672364541

I also need to do this same thing repeatedly to make retry gets timed out correctly.