### PR TITLE
chore: fix failing unit test

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -114,17 +114,23 @@ test('with number of retries', async t => {
   let retries = 0;
 
   try {
-    await retry(() => fetch('https://www.fakewikipedia.org'), {
-      retries: 2,
-      onRetry: (err, i) => {
-        if (err) {
-          // eslint-disable-next-line no-console
-          console.log('Retry error : ', err);
-        }
+    await retry(
+      async () => {
+        await sleep(100);
+        throw new Error('dummy error');
+      },
+      {
+        retries: 2,
+        onRetry: (err, i) => {
+          if (err) {
+            // eslint-disable-next-line no-console
+            console.log('Retry error : ', err);
+          }
 
-        retries = i;
+          retries = i;
+        },
       }
-    });
+    );
   } catch (err) {
     t.deepEqual(retries, 2);
   }


### PR DESCRIPTION
## Motivation
The `with number of retries` unit test is failing on the `main` branch.

The call to `fetch(...)` is lasting too long, and timing out the test. Since the details of `fetch` are outside the scope of the test, I simply modified it to throw an `Error` manually (instead of expecting `fetch` to throw an error).

## Steps to Reproduce
- `git checkout main`
- `nvm use 14` | `nvm use 16` | `nvm use 18` 
- `yarn test-unit`