### PR TITLE
feat: add support for aborting retrying using `AbortSignal`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ retry(retrier : Function, opts : Object) => Promise
   - `maxTimeout`: The maximum number of milliseconds between two retries. Default is `Infinity`.
   - `randomize`: Randomizes the timeouts by multiplying with a factor between `1` to `2`. Default is `true`.
   - `onRetry`: an optional `Function` that is invoked after a new retry is performed. It's passed the `Error` that triggered it as a parameter.
+  - `signal`: an `AbortController` signal that can be used to abort the retrying.
 
 ## Authors
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -53,6 +53,17 @@ function retry(fn, opts) {
     }
 
     op.attempt(runAttempt);
+
+    if (options.signal && !options.signal.aborted) {
+      options.signal.addEventListener(
+        'abort',
+        () => {
+          op.stop();
+          reject(options.signal.reason);
+        },
+        { once: true }
+      );
+    }
   }
 
   return new Promise(run);

--- a/test/index.js
+++ b/test/index.js
@@ -129,3 +129,34 @@ test('with number of retries', async t => {
     t.deepEqual(retries, 2);
   }
 });
+
+test('with aborting', async t => {
+  const controller = new AbortController();
+  const error = new Error('end retrying');
+
+  setTimeout(() => {
+    controller.abort(error);
+  }, 100);
+
+  let runs = 0;
+
+  try {
+    await retry(
+      async () => {
+        runs += 1;
+        await sleep(250);
+      },
+      { signal: controller.signal }
+    );
+  } catch (err) {
+    t.deepEqual(err, error);
+  }
+  // Assert it only ran once.
+  t.deepEqual(runs, 1);
+
+  // Wait some more, just to be sure.
+  await sleep(500);
+
+  // Assert it still has only run once.
+  t.deepEqual(runs, 1);
+});


### PR DESCRIPTION
## Motivation
This PR adds support for aborting retrying using the now-common `AbortController` / `AbortSignal` utilities via a new `signal` option.

This API allows for more flexibility in use cases that may need to imperatively stop the retrying from _outside_ of the retried function.

## Example
```typescript
import retry from 'async-retry';

const controller = new AbortController();

// This will stop the retrying after 500ms.
setTimeout(
  () => controller.abort(new Error('end retrying')),
  500
)

await retry(
  async () => {
    await wait(100)
    throw new Error('some failure')
  },
  {
    forever: true,
    signal: controller.signal
  }
)
```