### PR TITLE
chore: run CI against Node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ jobs:
     strategy:
       matrix:
         node-version:
+          - 18
           - 16
           - 14
     steps:


### PR DESCRIPTION
## Motivation
As of now, this package is working as expected on Node 18 (all tests pass). I'd like to propose adding Node 18 to the CI flow, to ensure that regressions don't arise.